### PR TITLE
Closes #4 - blackout seats

### DIFF
--- a/app/components/calendar/x-block.js
+++ b/app/components/calendar/x-block.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import moment from 'moment';
 
-const { Component, computed } = Ember;
+const { Component, A, computed } = Ember;
 
 export default Component.extend({
   tagName: 'button',
@@ -59,5 +59,23 @@ export default Component.extend({
 
   unsuitable: computed('inActiveBlocks', 'hover', function () {
     return !this.get('inActiveBlocks') && this.get('hover') ? true : false;
+  }),
+
+  seats: computed('block.information.{seats,onlyClasses,reduceSeats}', 'classes.[]', function () {
+    const {
+      seats,
+      onlyClasses,
+      reduceSeats
+    } = this.get('block.information') || {};
+
+    const selection = A(this.get('classes')).mapBy('id'),
+          cl = A(onlyClasses).mapBy('_id'),
+          reduced = seats - reduceSeats;
+
+    if (!reduceSeats) {
+      return seats;
+    }
+
+    return selection.find(c => cl.includes(c)) ? seats : reduced || 0;
   })
 });

--- a/app/components/calendar/x-calendar.js
+++ b/app/components/calendar/x-calendar.js
@@ -169,12 +169,18 @@ export default Component.extend({
         return unsuitable();
       }
 
-      if ( information && information.onlyClasses && information.onlyClasses && !allClassesInRestriction(information.onlyClasses) ) {
+      const inRestriction = information && information.onlyClasses && !allClassesInRestriction(information.onlyClasses);
+
+      if (inRestriction && !information.reduceSeats) {
         this.set('registerWarning', 'The classes you have selected fall within a class-specific blackout date.');
         return unsuitable();
       }
 
-      if ( information && information.seats < numberRegistering ) {
+      if (inRestriction && information.seats - information.reduceSeats < 1) {
+        return unsuitable();
+      }
+
+      if (information && information.seats < numberRegistering) {
         this.set('registerWarning', `Only ${information.seats} will be able to register for this time block.`);
       }
 

--- a/app/models/blackout-date.js
+++ b/app/models/blackout-date.js
@@ -5,6 +5,7 @@ import { hasMany } from 'ember-data/relationships';
 export default Model.extend({
   start: attr('date'),
   end: attr('date'),
+  seats: attr('number'),
 
   classExceptions: hasMany('class', { inverse: null }),
   blocks: attr('array')

--- a/app/templates/classes/blackouts/index.hbs
+++ b/app/templates/classes/blackouts/index.hbs
@@ -6,6 +6,7 @@
         <th>Ends</th>
         <th>Times</th>
         <th>Allowed Classes</th>
+        <th>Reserve Seats</th>
         <th></th>
       </tr>
     </thead>

--- a/app/templates/classes/blackouts/new.hbs
+++ b/app/templates/classes/blackouts/new.hbs
@@ -30,6 +30,11 @@
   {{/bulma-control}}
 
   {{#if model.classExceptions.length}}
+    {{#bulma-control}}
+      <label for="reserve-seats">Number of seats to reserve</label>
+      {{bulma-input type="number" id="reserve-seats" oninput=(action (mut model.seats) value='target.value')}}
+    {{/bulma-control}}
+
     <div>
       <label for="block-selection">Enter blackout blocks (two hour, even increments in 24 hour format)</label>
     </div>

--- a/app/templates/components/blocks/x-nav.hbs
+++ b/app/templates/components/blocks/x-nav.hbs
@@ -22,6 +22,9 @@
         {{#link-to 'available-times' class="nav-item"}}
           Availability Configuration
         {{/link-to}}
+        {{#link-to 'classes.blackouts' class="nav-item"}}
+          Blackout Configuration
+        {{/link-to}}
         {{#link-to 'classes.index' class="nav-item"}}
           Classes
         {{/link-to}}

--- a/app/templates/components/calendar/x-block.hbs
+++ b/app/templates/components/calendar/x-block.hbs
@@ -2,7 +2,7 @@
   <span class="cal__block-label--extended">{{block.start}}-{{block.end}}</span>
   <span class="cal__block-label--minimal">{{time block.startF 'h'}}-{{time block.endF 'h'}}</span>
   <span class="cal__avail-seats">
-    {{block.information.seats}} Seats
+    {{seats}} Seats
   </span>
 {{else}}
   <span>{{block.start}}-{{block.end}}</span>

--- a/app/templates/components/calendar/x-calendar.hbs
+++ b/app/templates/components/calendar/x-calendar.hbs
@@ -24,7 +24,17 @@
   {{#each _weeks as |week weekIndex|}}
     <ul class="cal__list-days">
       {{#each week.days as |day|}}
-        {{calendar/x-day day=day availability=availability week=weekIndex activeBlocks=activeBlocks registerWarning=registerWarning focusBlock=(action 'focusBlock') unfocusBlock=(action 'unfocusBlock') register=register class="animated fadeIn"}}
+        {{calendar/x-day
+          day=day
+          availability=availability
+          week=weekIndex
+          activeBlocks=activeBlocks
+          registerWarning=registerWarning
+          classes=classes
+          focusBlock=(action 'focusBlock')
+          unfocusBlock=(action 'unfocusBlock')
+          register=register
+          class="animated fadeIn"}}
       {{/each}}
     </ul>
   {{/each}}

--- a/app/templates/components/calendar/x-day.hbs
+++ b/app/templates/components/calendar/x-day.hbs
@@ -8,6 +8,7 @@
         focusBlock=focusBlock
         unfocusBlock=unfocusBlock
         date=day.date
+        classes=classes
         registerWarning=registerWarning
         onClick=register}}
     {{/each}}

--- a/app/templates/components/list/class-blackout-item.hbs
+++ b/app/templates/components/list/class-blackout-item.hbs
@@ -15,5 +15,8 @@
   {{/each}}
 </td>
 <td>
+  {{or model.seats 'N/A'}}
+</td>
+<td>
   <a href="#" {{action "delete"}}><i class="fa fa-trash-o"></i></a>
 </td>


### PR DESCRIPTION
This PR helps close #4 by:

- Adding seats to class blackout models/forms/views
- Morphing calendar seats displayed in order to show accurate counts when class blackouts are associated with seats
